### PR TITLE
Fix PHP 5.6 SSL connections

### DIFF
--- a/src/php/Image.php
+++ b/src/php/Image.php
@@ -431,7 +431,18 @@ class Image
         $chunkSize = 1024 * 8;
 
         // open remote file
-        $remoteFile = @fopen($this->pathFile, 'rb');
+        $arrContextOptions=array(
+            "ssl"=>array(
+                "verify_peer"=>false,
+                "verify_peer_name"=>false,
+            ),
+        );
+        $remoteFile = fopen(
+            $this->pathFile,
+            'rb',
+            null,
+            stream_context_create($arrContextOptions)
+        );
         if (!$remoteFile) {
             throw new \RuntimeException(
                 sprintf(


### PR DESCRIPTION
Disable strict SSL checks for PHP 5.6